### PR TITLE
feat: add password reset form

### DIFF
--- a/controller/firebase.js
+++ b/controller/firebase.js
@@ -11,7 +11,8 @@ import {
   signInWithEmailLink,
   signOut,
   signInWithEmailAndPassword,
-  createUserWithEmailAndPassword
+  createUserWithEmailAndPassword,
+  sendPasswordResetEmail
 } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-auth.js";
 
 import {
@@ -214,4 +215,4 @@ export async function getFlightById(sn, flightId) {
 }
 
 // ===== Re-export para que login/logout importen desde ./firebase.js (solución 1)
-export { onAuthStateChanged, signInWithEmailAndPassword, signOut };
+export { onAuthStateChanged, signInWithEmailAndPassword, signOut, sendPasswordResetEmail };

--- a/controller/login.js
+++ b/controller/login.js
@@ -1,10 +1,18 @@
 // /controller/login.js
-import { auth, signInWithEmailAndPassword, onAuthStateChanged } from './firebase.js';
+import { auth, signInWithEmailAndPassword, onAuthStateChanged, sendPasswordResetEmail } from './firebase.js';
 
-const form       = document.getElementById('login-form');
-const emailInput = document.getElementById('email');
-const passInput  = document.getElementById('password');
-const toggleIcon = document.getElementById('togglePassword');
+const form        = document.getElementById('login-form');
+const emailInput  = document.getElementById('email');
+const passInput   = document.getElementById('password');
+const toggleIcon  = document.getElementById('togglePassword');
+const forgotLink  = document.getElementById('forgot-pass');
+const msgBox      = document.getElementById('msg');
+
+function showMessage(text, type = '') {
+  if (!msgBox) return;
+  msgBox.textContent = text;
+  msgBox.className = type ? `status ${type}` : 'status';
+}
 
 if (toggleIcon && passInput) {
   toggleIcon.addEventListener('click', () => {
@@ -24,10 +32,28 @@ form?.addEventListener('submit', async (e) => {
     location.href = '/views/inicio.html';
   } catch (err) {
     console.error('Error al iniciar sesión:', err);
-    alert(`Error al iniciar sesión: ${err.code || err.message}`);
+    showMessage(`Error al iniciar sesión: ${err.code || err.message}`, 'error');
   }
 });
 
 onAuthStateChanged(auth, (user) => {
   if (user) location.href = '/views/inicio.html';
 });
+
+forgotLink?.addEventListener('click', async (e) => {
+  e.preventDefault();
+  const email = (emailInput?.value || '').trim();
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(email)) {
+    showMessage('Ingresa un correo válido', 'error');
+    return;
+  }
+  try {
+    await sendPasswordResetEmail(auth, email);
+    showMessage('Se envió un correo para restablecer la contraseña', 'success');
+  } catch (err) {
+    console.error('Error al restablecer contraseña:', err);
+    showMessage(`Error: ${err.code || err.message}`, 'error');
+  }
+});
+

--- a/index.html
+++ b/index.html
@@ -39,6 +39,10 @@
           </div>
           <button class="btn" type="submit">INGRESAR</button>
         </form>
+        <div class="meta">
+          <a href="#" id="forgot-pass">¿Olvidaste tu contraseña?</a>
+        </div>
+        <p id="msg" class="status"></p>
       </div>
     </section>
   </div>

--- a/styles/index.css
+++ b/styles/index.css
@@ -161,6 +161,14 @@ body {
   text-decoration: underline;
 }
 
+.status {
+  margin-top: 8px;
+  font-size: 13px;
+}
+
+.status.error { color: #dc2626; }
+.status.success { color: #16a34a; }
+
 /* ===== Lado derecho: bienvenida ===== */
 .login-right {
   position: relative;


### PR DESCRIPTION
## Summary
- replace prompt-based reset with visible link
- display inline success and error messages
- validate email format before sending password reset

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Missing script "lint")

------
https://chatgpt.com/codex/tasks/task_e_68c4de86ee2c8333b3d5931fcbd3cb07