### PR TITLE
Improve report resilience and signature handling

### DIFF
--- a/controller/postvuelo.js
+++ b/controller/postvuelo.js
@@ -44,7 +44,10 @@ function clearCanvas(canvas){
 }
 
 function setupDraw(canvas){
+  if (!canvas) return;
   ensureCanvasScale(canvas);
+  if (canvas.dataset.dfrDrawBound === '1') return;
+  canvas.dataset.dfrDrawBound = '1';
   const ctx = canvas.getContext('2d');
   let drawing = false;
   let last = null;
@@ -96,6 +99,7 @@ if(!sn) location.href = '/views/inicio.html';
 let currentFlight = null;   // { startTime, endTime, durationMin, preflight, ... }
 let durationMin   = 0;
 let drone         = null;
+let localFlightData = null;
 
 // ====== DOM ======
 const formPost     = document.getElementById('post-form');
@@ -132,20 +136,25 @@ async function boot(){
     let useLocalData = false;
     
     if (lastFlightData) {
-      const localData = JSON.parse(lastFlightData);
-      if (localData.finished) {
-        // Usar datos del localStorage para el cronómetro
-        f = {
-          id: localStorage.getItem('dfr:currentFlightId'),
-          startTime: localData.startTime,
-          endTime: localData.endTime,
-          durationMin: localData.durationMin,
-          timeline: localData.timeline,
-          status: 'completed'
-        };
-        currentFlight = f;
-        durationMin = Number(f.durationMin) || 0;
-        useLocalData = true;
+      try {
+        const localData = JSON.parse(lastFlightData);
+        localFlightData = localData;
+        if (localData.finished) {
+          // Usar datos del localStorage para el cronómetro
+          f = {
+            id: localData.flightId || localStorage.getItem('dfr:currentFlightId'),
+            startTime: localData.startTime,
+            endTime: localData.endTime,
+            durationMin: localData.durationMin,
+            timeline: localData.timeline,
+            status: 'completed'
+          };
+          currentFlight = f;
+          durationMin = Number(f.durationMin) || 0;
+          useLocalData = true;
+        }
+      } catch (err) {
+        console.warn('No se pudo interpretar dfr:lastFlightData:', err);
       }
     }
     
@@ -165,7 +174,7 @@ async function boot(){
     let preflightData = null;
     if (useLocalData) {
       // Si usamos datos locales, necesitamos obtener el prevuelo por separado
-      const flightId = localStorage.getItem('dfr:currentFlightId');
+      const flightId = localStorage.getItem('dfr:currentFlightId') || localFlightData?.flightId || null;
       if (flightId) {
         try {
           const flightData = await getFlightById(sn, flightId);
@@ -379,7 +388,7 @@ formPost?.addEventListener('submit', async (e)=>{
   data['nombre_ing_vuelo']      = nameIng?.value   || null;
 
   try{
-    const flightId = localStorage.getItem('dfr:currentFlightId') || currentFlight?.id || null;
+    const flightId = localStorage.getItem('dfr:currentFlightId') || localFlightData?.flightId || currentFlight?.id || null;
     if(!flightId){
       console.warn('No hay flightId en LS; se usará el último vuelo terminado.');
     }

--- a/controller/report.js
+++ b/controller/report.js
@@ -14,21 +14,31 @@ const setHTML = (id, html) => {
   nodes.forEach(el => { el.innerHTML = html ?? ''; });
 };
 
+const safeParse = (raw, key) => {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    console.warn(`No se pudo interpretar ${key}:`, err);
+    return null;
+  }
+};
+
 (async () => {
   // Obtener datos del localStorage
   const lastFlightData = localStorage.getItem('dfr:lastFlightData');
   const preflightData = localStorage.getItem('dfr:preflightData');
   const postflightData = localStorage.getItem('dfr:postflightData');
-  
-  if (!lastFlightData) {
-    console.warn('No hay datos de vuelo en localStorage');
+
+  const flightData = safeParse(lastFlightData, 'dfr:lastFlightData');
+  if (!flightData) {
+    console.warn('No hay datos de vuelo válidos en localStorage');
     return;
   }
 
   // Parsear datos del localStorage
-  const flightData = JSON.parse(lastFlightData);
-  const pre = preflightData ? JSON.parse(preflightData) : {};
-  const post = postflightData ? JSON.parse(postflightData) : {};
+  const pre = safeParse(preflightData, 'dfr:preflightData') || {};
+  const post = safeParse(postflightData, 'dfr:postflightData') || {};
   
   // Obtener datos de la aeronave desde Firebase
   const ac = await getDrone(sn).catch(() => null);
@@ -146,18 +156,52 @@ const setHTML = (id, html) => {
   document.addEventListener('DOMContentLoaded', () => {
     const btnP = document.getElementById('btnPrint');
     const btnS = document.getElementById('btnSave');
+
+    const toggleButtons = (hidden) => {
+      if (btnP) btnP.style.display = hidden ? 'none' : '';
+      if (btnS) {
+        btnS.style.display = hidden ? 'none' : '';
+        btnS.disabled = hidden;
+      }
+    };
+
+    const restoreButtonsAfterPrint = () => {
+      toggleButtons(false);
+    };
+
     if (btnP) {
       btnP.addEventListener('click', () => {
-        btnP.style.display = 'none';
-        btnS?.style.display = 'none';
+        toggleButtons(true);
+
+        const handleAfterPrint = () => {
+          window.removeEventListener('afterprint', handleAfterPrint);
+          restoreButtonsAfterPrint();
+        };
+        window.addEventListener('afterprint', handleAfterPrint, { once: true });
+
+        const mq = window.matchMedia?.('print');
+        if (mq) {
+          const handler = (e) => {
+            if (!e.matches) {
+              mq.removeEventListener?.('change', handler);
+              mq.removeListener?.(handler);
+              restoreButtonsAfterPrint();
+            }
+          };
+          mq.addEventListener?.('change', handler);
+          mq.addListener?.(handler);
+        }
+
+        // Fallback en caso de que los eventos anteriores no estén disponibles
+        setTimeout(restoreButtonsAfterPrint, 0);
+
         window.print();
       });
     }
+
     if (btnS) {
       btnS.addEventListener('click', async () => {
-        btnP.style.display = 'none';
-        btnS.disabled = true;
-        btnS.style.display = 'none';
+        toggleButtons(true);
         try {
           const fileName = `reporte${pre.code || '0000'}-${sn}`;
           const pdfBlob = await html2pdf().from(document.body).output('blob');
@@ -174,9 +218,9 @@ const setHTML = (id, html) => {
           await saveReport(sn, { name: fileName, url: data.secure_url });
         } catch (err) {
           console.error(err);
-          btnP.style.display = '';
-          btnS.style.display = '';
-          btnS.disabled = false;
+          alert('No se pudo guardar el reporte. Intenta nuevamente.');
+        } finally {
+          toggleButtons(false);
         }
       });
     }

--- a/controller/vuelo.js
+++ b/controller/vuelo.js
@@ -1,5 +1,5 @@
 // /controller/vuelo.js
-import { setFlightStart, setFlightEnd, addMinutes } from './firebase.js';
+import { setFlightStart, setFlightEnd, addMinutes, getFlightById } from './firebase.js';
 
 const go = (p) => (location.href = new URL(p, location.href).toString());
 
@@ -73,8 +73,7 @@ function addMarker(phase){
 
   timeline.push({ t: segundos, phase });
 
-  const pct = Math.min(100, (segundos / Math.max(1, segundos)) * 100);
-  el.style.left = pct + '%';
+  layoutMarkers(segundos || 1);
 }
 
 async function startFlight(){
@@ -113,10 +112,11 @@ async function stopFlight(){
   
   // Guardar datos del vuelo en localStorage para el postvuelo
   const flightData = {
+    flightId,
     startTime: new Date(startMs).toISOString(),
-    endTime: endTime,
-    durationMin: durationMin,
-    timeline: timeline,
+    endTime,
+    durationMin,
+    timeline,
     finished: true
   };
   localStorage.setItem('dfr:lastFlightData', JSON.stringify(flightData));
@@ -153,11 +153,37 @@ for(const [id,label] of phases){
 }
 
 // Verificar si ya hay un vuelo terminado al cargar la página
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
   const lastFlightData = localStorage.getItem('dfr:lastFlightData');
   if (lastFlightData) {
-    const data = JSON.parse(lastFlightData);
-    if (data.finished && data.flightId === flightId) {
+    let data;
+    try {
+      data = JSON.parse(lastFlightData);
+    } catch (err) {
+      console.warn('No se pudo interpretar lastFlightData:', err);
+      return;
+    }
+    if (!data.flightId && flightId) {
+      data.flightId = flightId;
+      localStorage.setItem('dfr:lastFlightData', JSON.stringify(data));
+    }
+
+    if (!data.finished) return;
+
+    let shouldRestore = !flightId || data.flightId === flightId;
+
+    if (shouldRestore && data.flightId) {
+      try {
+        const serverFlight = await getFlightById(sn, data.flightId);
+        if (!serverFlight || serverFlight.status !== 'completed') {
+          shouldRestore = false;
+        }
+      } catch (err) {
+        console.warn('No se pudo verificar el estado del vuelo en Firestore:', err);
+      }
+    }
+
+    if (shouldRestore) {
       finished = true;
       segundos = data.durationMin * 60;
       timeline = data.timeline || [];


### PR DESCRIPTION
## Summary
- persist the current flight identifier in local storage and validate it against Firestore before restoring a finished flight
- keep timeline markers aligned when adding phases after a reload
- make the post-flight form fall back to the stored flight identifier and tolerate malformed cached data
- harden the report view against malformed cached data and restore print/save controls after they are used
- prevent duplicate signature event bindings on the post-flight canvases

## Testing
- not run (project has no automated tests)

------
https://chatgpt.com/codex/tasks/task_e_68d6decc79c483339d34f46966638e28